### PR TITLE
Updated core.py resolved import of SmilesTokenizer

### DIFF
--- a/rxn_yields/core.py
+++ b/rxn_yields/core.py
@@ -10,3 +10,4 @@ import random
 import pkg_resources
 
 from rxnfp.models import SmilesClassificationModel
+from rxnfp.tokenization import SmilesTokenizer


### PR DESCRIPTION
Resolved the following error  
```  File "training_scripts/launch_suzuki_miyaura_training.py", line 13, in <module>
    from rxn_yields.core import SmilesTokenizer, SmilesClassificationModel
ImportError: cannot import name 'SmilesTokenizer' from 'rxn_yields.core' (/content/rxn_yields/rxn_yields/core.py) ```


